### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # FrAgeEst
+This is an extension for the age estimation of adults utilising cranial and dental traits. The Freiburg method of age estimation (abbr. FrAgeEst) is a morphological method based on the scoring system developed in Vallois 1937 and adjusted by Hermann et al. 1990.  Furthermore, the dental abrasion is based on the scoring system developed by  Miles (1963) and Hermann et al. (1990). In addition, age groups following Knußman (1996) can be determined.
+
+The traits of the degree of ectocranial suture closure are evaluated according to Hermann et al. 1990. The ten cranial suture traits of FrAgeEst were used in the age estimation of skulls from the Alexander-Ecker-Collection in Freiburg. 
+
+Additionaly, the Sphenofrontal suture and the sphenoparietal suture are evaluated. 
+
+Thus, the collected data from the Alexander-Ecker-Collection can be digitized and made accessible for future research within the flexible RDFBones-Ontology. Of course, the Freiburg method of age estimation can be applied to estimate the age of any human skull.
+
+References:
+
+Vallois, H.V., La duree de la vie chez l'homme fossile. (1937), L'Anthropologie, Vol. 47, Dec.
+
+Bernd Herrmann/Gisela Grupe/Susanne Hummel/Hermann Piepenbrink/ Holger Schutkowski, Prähistorische Anthropologie. Leitfaden der Feld- und Labormethoden (Berlin/Heidelberg 1990), 67, Abb. 3.2.1.8.
+
+A.E.W. Miles, The dentition in the assessment of individual age in skeletal material, in: D.R. Brothwell (Hrsg.), Dental anthropologie (Oxford 1963), 191-209, Fig. 10
+R. Knußmann, Vergleichende Biologie des Menschen, Lehrbuch der Anthropologie und Humangenetik (Stuttgart 1996), 169


### PR DESCRIPTION
This is an extension for the age estimation of adults utilising cranial and dental traits. The Freiburg method of age estimation (abbr. FrAgeEst) is a morphological method based on the scoring system developed in Vallois 1937 and adjusted by Hermann et al. 1990.  Furthermore, the dental abrasion is based on the scoring system developed by  Miles (1963) and Hermann et al. (1990). In addition, age groups following Knußman (1996) can be determined.

The traits of the degree of ectocranial suture closure are evaluated according to Hermann et al. 1990. The ten cranial suture traits of FrAgeEst were used in the age estimation of skulls from the Alexander-Ecker-Collection in Freiburg. 

Additionaly, the Sphenofrontal suture and the sphenoparietal suture are evaluated. 

Thus, the collected data from the Alexander-Ecker-Collection can be digitized and made accessible for future research within the flexible RDFBones-Ontology. Of course, the Freiburg method of age estimation can be applied to estimate the age of any human skull.

References:

Vallois, H.V., La duree de la vie chez l'homme fossile. (1937), L'Anthropologie, Vol. 47, Dec.

Bernd Herrmann/Gisela Grupe/Susanne Hummel/Hermann Piepenbrink/ Holger Schutkowski, Prähistorische Anthropologie. Leitfaden der Feld- und Labormethoden (Berlin/Heidelberg 1990), 67, Abb. 3.2.1.8.

A.E.W. Miles, The dentition in the assessment of individual age in skeletal material, in: D.R. Brothwell (Hrsg.), Dental anthropologie (Oxford 1963), 191-209, Fig. 10
R. Knußmann, Vergleichende Biologie des Menschen, Lehrbuch der Anthropologie und Humangenetik (Stuttgart 1996), 169
